### PR TITLE
feat: add memo & missing routes

### DIFF
--- a/src/app/(route)/api/bookmark/get.ts
+++ b/src/app/(route)/api/bookmark/get.ts
@@ -1,0 +1,37 @@
+import { ApiResponse, ErrorCode, ErrorResponse } from '@/app/_constant/api';
+import { authorize } from '@/app/_utils/server/authorization';
+import { createSupabaseServerClient } from '@/app/_utils/supabase/server';
+import { NextResponse } from 'next/server';
+
+export const getBookmarks = async () => {
+  const supabase = createSupabaseServerClient();
+
+  const authorizationResult = await authorize(supabase);
+  if (!authorizationResult.isSuccess) {
+    return authorizationResult.response;
+  }
+
+  const { user } = authorizationResult;
+
+  const result = await supabase
+    .from('bookmark')
+    .select('*')
+    .eq('user_id', user.id)
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false });
+
+  if (result.error) {
+    return NextResponse.json(
+      new ErrorResponse({
+        status: result.status,
+        message: result.statusText,
+        errorCode: ErrorCode.SUPABASE_ERROR,
+      }),
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json(new ApiResponse(result.data), {
+    status: 200,
+  });
+};

--- a/src/app/(route)/api/bookmark/post.ts
+++ b/src/app/(route)/api/bookmark/post.ts
@@ -1,0 +1,52 @@
+import { ApiResponse, ErrorCode, ErrorResponse } from '@/app/_constant/api';
+import { authorize } from '@/app/_utils/server/authorization';
+import { parseRequest } from '@/app/_utils/server/validation';
+import { createSupabaseServerClient } from '@/app/_utils/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const requestSchema = z.object({
+  story_id: z.number(),
+});
+
+export const postBookmark = async (request: NextRequest) => {
+  const body = await request.json();
+
+  const validationResult = parseRequest(requestSchema, body);
+  if (!validationResult.isSuccess) {
+    return validationResult.response;
+  }
+
+  const supabase = createSupabaseServerClient();
+
+  const authorizationResult = await authorize(supabase);
+  if (!authorizationResult.isSuccess) {
+    return authorizationResult.response;
+  }
+
+  const { user } = authorizationResult;
+
+  const result = await supabase
+    .from('bookmark')
+    .insert({
+      story_id: validationResult.data.story_id,
+      user_id: user.id,
+    })
+    .select('*')
+    .single();
+
+  if (result.error) {
+    return NextResponse.json(
+      new ErrorResponse({
+        status: result.status,
+        message: result.statusText,
+        errorCode: ErrorCode.SUPABASE_ERROR,
+      }),
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json(new ApiResponse(result.data), {
+    status: 201,
+  });
+};

--- a/src/app/(route)/api/bookmark/route.ts
+++ b/src/app/(route)/api/bookmark/route.ts
@@ -1,0 +1,5 @@
+import { getBookmarks } from './get';
+import { postBookmark } from './post';
+
+export const GET = getBookmarks;
+export const POST = postBookmark;

--- a/src/app/(route)/api/note/get.ts
+++ b/src/app/(route)/api/note/get.ts
@@ -1,0 +1,37 @@
+import { ApiResponse, ErrorCode, ErrorResponse } from '@/app/_constant/api';
+import { authorize } from '@/app/_utils/server/authorization';
+import { createSupabaseServerClient } from '@/app/_utils/supabase/server';
+import { NextResponse } from 'next/server';
+
+export const getNotes = async () => {
+  const supabase = createSupabaseServerClient();
+
+  const authorizationResult = await authorize(supabase);
+  if (!authorizationResult.isSuccess) {
+    return authorizationResult.response;
+  }
+
+  const { user } = authorizationResult;
+
+  const result = await supabase
+    .from('note')
+    .select('*')
+    .eq('user_id', user.id)
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false });
+
+  if (result.error) {
+    return NextResponse.json(
+      new ErrorResponse({
+        status: result.status,
+        message: result.statusText,
+        errorCode: ErrorCode.SUPABASE_ERROR,
+      }),
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json(new ApiResponse(result.data), {
+    status: 200,
+  });
+};

--- a/src/app/(route)/api/note/post.ts
+++ b/src/app/(route)/api/note/post.ts
@@ -1,0 +1,52 @@
+import { ApiResponse, ErrorCode, ErrorResponse } from '@/app/_constant/api';
+import { authorize } from '@/app/_utils/server/authorization';
+import { parseRequest } from '@/app/_utils/server/validation';
+import { createSupabaseServerClient } from '@/app/_utils/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const requestSchema = z.object({
+  content: z.string(),
+});
+
+export const postNote = async (request: NextRequest) => {
+  const body = await request.json();
+
+  const validationResult = parseRequest(requestSchema, body);
+  if (!validationResult.isSuccess) {
+    return validationResult.response;
+  }
+
+  const supabase = createSupabaseServerClient();
+
+  const authorizationResult = await authorize(supabase);
+  if (!authorizationResult.isSuccess) {
+    return authorizationResult.response;
+  }
+
+  const { user } = authorizationResult;
+
+  const result = await supabase
+    .from('note')
+    .insert({
+      content: validationResult.data.content,
+      user_id: user.id,
+    })
+    .select('*')
+    .single();
+
+  if (result.error) {
+    return NextResponse.json(
+      new ErrorResponse({
+        status: result.status,
+        message: result.statusText,
+        errorCode: ErrorCode.SUPABASE_ERROR,
+      }),
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json(new ApiResponse(result.data), {
+    status: 201,
+  });
+};

--- a/src/app/(route)/api/note/route.ts
+++ b/src/app/(route)/api/note/route.ts
@@ -1,0 +1,5 @@
+import { getNotes } from './get';
+import { postNote } from './post';
+
+export const GET = getNotes;
+export const POST = postNote;

--- a/src/app/(route)/api/story/temporary/[id]/route.ts
+++ b/src/app/(route)/api/story/temporary/[id]/route.ts
@@ -1,0 +1,65 @@
+import { ApiResponse, ErrorCode, ErrorResponse } from '@/app/_constant/api';
+import { authorize } from '@/app/_utils/server/authorization';
+import { parseRequest } from '@/app/_utils/server/validation';
+import { createSupabaseServerClient } from '@/app/_utils/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const requestSchema = z.object({
+  id: z.number(),
+});
+
+export const GET = async (
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) => {
+  const validationResult = parseRequest(requestSchema, {
+    id: Number(params.id),
+  });
+
+  if (!validationResult.isSuccess) {
+    return validationResult.response;
+  }
+
+  const { id } = validationResult.data;
+
+  const supabase = createSupabaseServerClient();
+
+  const authorizationResult = await authorize(supabase);
+  if (!authorizationResult.isSuccess) {
+    return authorizationResult.response;
+  }
+
+  const { user } = authorizationResult;
+
+  const result = await supabase
+    .from('temporary_story')
+    .select('*')
+    .eq('id', id)
+    .is('deleted_at', null)
+    .single();
+
+  if (result.error) {
+    return NextResponse.json(
+      new ErrorResponse({
+        status: result.status,
+        message: result.statusText,
+        errorCode: ErrorCode.SUPABASE_ERROR,
+      }),
+      { status: result.status },
+    );
+  }
+
+  if (result.data.user_id !== user.id) {
+    return NextResponse.json(
+      new ErrorResponse({
+        status: 401,
+        message: '본인의 임시 저장 스토리가 아닙니다',
+        errorCode: ErrorCode.NOT_OWNED_CONTENT,
+      }),
+      { status: 401 },
+    );
+  }
+
+  return NextResponse.json(new ApiResponse(result.data), { status: 200 });
+};

--- a/src/app/(route)/api/user/me/stories/route.ts
+++ b/src/app/(route)/api/user/me/stories/route.ts
@@ -1,0 +1,36 @@
+import { ApiResponse, ErrorCode, ErrorResponse } from '@/app/_constant/api';
+import { authorize } from '@/app/_utils/server/authorization';
+import { createSupabaseServerClient } from '@/app/_utils/supabase/server';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const GET = async (request: NextRequest) => {
+  const supabase = createSupabaseServerClient();
+
+  const authorizationResult = await authorize(supabase);
+  if (!authorizationResult.isSuccess) {
+    return authorizationResult.response;
+  }
+
+  const { user } = authorizationResult;
+
+  const result = await supabase
+    .from('story')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (result.error) {
+    return NextResponse.json(
+      new ErrorResponse({
+        status: result.status,
+        message: result.statusText,
+        errorCode: ErrorCode.SUPABASE_ERROR,
+      }),
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json(new ApiResponse(result.data), {
+    status: 200,
+  });
+};

--- a/src/app/_constant/type/supabase.ts
+++ b/src/app/_constant/type/supabase.ts
@@ -153,6 +153,38 @@ export type Database = {
           },
         ]
       }
+      note: {
+        Row: {
+          content: string
+          created_at: string
+          deleted_at: string | null
+          id: number
+          user_id: number
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          deleted_at?: string | null
+          id?: number
+          user_id: number
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          deleted_at?: string | null
+          id?: number
+          user_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "note_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       sentence: {
         Row: {
           content: string


### PR DESCRIPTION
## Description

- memo(문장 조각 보관) 도메인을 추가하고 GET, POST API를 추가했습니다.
- 내가 쓴 스토리 목록 조회 API를 추가했습니다.
- 임시 저장한 스토리를 id로 개별 조회할 수 있는 API를 추가했습니다.
- 스토리 북마크 API를 추가했습니다.

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
