### PR TITLE
feat: correct api behavior

### DIFF
--- a/src/app/(route)/api/story/temporary/get.ts
+++ b/src/app/(route)/api/story/temporary/get.ts
@@ -11,7 +11,7 @@ export const getTemporaryStory = async (request: NextRequest) => {
     return authorizationResult.response;
   }
 
-  const user = authorizationResult.user;
+  const { user } = authorizationResult;
 
   const result = await supabase
     .from('temporary_story')
@@ -30,7 +30,7 @@ export const getTemporaryStory = async (request: NextRequest) => {
     );
   }
 
-  return NextResponse.json(new ApiResponse(result.data.at(0) ?? null), {
+  return NextResponse.json(new ApiResponse(result.data), {
     status: 200,
   });
 };


### PR DESCRIPTION
## Description

- GET `/story/feed` API에 `limit` query param을 추가했습니다. 예를 들어 `limit=4`이면 최대 4개의 스토리를 반환합니다.
- GET `/story/temporary` API가 임시 저장 스토리를 여러 개 반환하도록 수정했습니다.

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
