### PR TITLE
feat: add sentence recommendation

### DIFF
--- a/src/app/(route)/api/sentence/recommendation/route.ts
+++ b/src/app/(route)/api/sentence/recommendation/route.ts
@@ -44,8 +44,6 @@ export const POST = async (request: NextRequest) => {
   );
   const tags: string[] = tagAiJsonResult.categories;
 
-  console.log(tags);
-
   const sentencesResponse = await supabase
     .from('sentence_tag')
     .select(
@@ -74,7 +72,6 @@ export const POST = async (request: NextRequest) => {
 
   const sentenceStoryIdMap: Record<string, number> = {};
   sentencesResponse.data.forEach((tagItem) => {
-    console.log(tagItem.value);
     tagItem.sentence_tag_log.forEach((tagLogItem) => {
       if (tagLogItem.sentence) {
         sentenceStoryIdMap[tagLogItem.sentence.content] =

--- a/src/app/(route)/api/sentence/recommendation/route.ts
+++ b/src/app/(route)/api/sentence/recommendation/route.ts
@@ -1,0 +1,99 @@
+import { ApiResponse, ErrorCode, ErrorResponse } from '@/app/_constant/api';
+import { getShuffledArray } from '@/app/_utils/algorithm';
+import { openai } from '@/app/_utils/openai';
+import { parseRequest } from '@/app/_utils/server/validation';
+import { createSupabaseServerClient } from '@/app/_utils/supabase/server';
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+
+const requestSchema = z.object({
+  sentence: z.string().min(1),
+});
+
+export const POST = async (request: NextRequest) => {
+  const body = await request.json();
+
+  const validationResult = parseRequest(requestSchema, body);
+  if (!validationResult.isSuccess) {
+    return validationResult.response;
+  }
+
+  const supabase = createSupabaseServerClient();
+
+  const tagAiResponse = await openai.chat.completions.create({
+    model: 'gpt-4-turbo-preview',
+    messages: [
+      {
+        role: 'system',
+        content: `당신은 수필 전문가입니다. 수필의 문장을 보고 그 문장이 속한 카테고리를 소재 측면에서 나열해 주세요. 응답은 다음 JSON 형식으로 해주세요:
+        {
+          "content": "문장",
+          "categories": ["소재 측면 카테고리"],
+        }`,
+      },
+      {
+        role: 'user',
+        content: `${validationResult.data.sentence}`,
+      },
+    ],
+    response_format: { type: 'json_object' },
+  });
+
+  const tagAiJsonResult = JSON.parse(
+    tagAiResponse.choices[0].message.content ?? '{}',
+  );
+  const tags: string[] = tagAiJsonResult.categories;
+
+  console.log(tags);
+
+  const sentencesResponse = await supabase
+    .from('sentence_tag')
+    .select(
+      `
+  *,
+  sentence_tag_log (
+    sentence (
+      *
+    )
+  )
+  `,
+    )
+    .in('value', tags);
+
+  if (sentencesResponse.error) {
+    return NextResponse.json(
+      new ErrorResponse({
+        status: sentencesResponse.status,
+        message: sentencesResponse.statusText,
+        errorCode: ErrorCode.SUPABASE_ERROR,
+        extra: sentencesResponse.error,
+      }),
+      { status: sentencesResponse.status },
+    );
+  }
+
+  const sentenceStoryIdMap: Record<string, number> = {};
+  sentencesResponse.data.forEach((tagItem) => {
+    console.log(tagItem.value);
+    tagItem.sentence_tag_log.forEach((tagLogItem) => {
+      if (tagLogItem.sentence) {
+        sentenceStoryIdMap[tagLogItem.sentence.content] =
+          tagLogItem.sentence.story_id;
+      }
+    });
+  });
+
+  const sentences = Object.keys(sentenceStoryIdMap).map((item) => ({
+    sentence: item,
+    story_id: sentenceStoryIdMap[item],
+  }));
+
+  if (sentences.length < 3) {
+    return NextResponse.json(new ApiResponse(sentences), { status: 200 });
+  }
+
+  return NextResponse.json(
+    new ApiResponse(getShuffledArray(sentences).slice(0, 3)),
+    { status: 200 },
+  );
+};

--- a/src/app/(route)/api/story/[id]/patch.ts
+++ b/src/app/(route)/api/story/[id]/patch.ts
@@ -56,8 +56,6 @@ export const patchStory = async (
     );
   }
 
-  console.log(storyResponse.data);
-
   if (user.id !== storyResponse.data.user_id) {
     return NextResponse.json(
       new ErrorResponse({

--- a/src/app/(route)/write/page.tsx
+++ b/src/app/(route)/write/page.tsx
@@ -33,6 +33,7 @@ import { CircleIcon } from '@/app/_components/atoms';
 import { postTemporary } from '@/app/userApi/postTemporary';
 import Loading from '@/app/_components/atoms/Loading';
 import { StoryForm } from '@/app/userApi/common/type';
+import Link from 'next/link';
 
 const MAIN_TEXT = '타인에게서\n자신의 이야기를\n발견하세요.';
 const INTRO_TEXT = '타인에게서\n자신의 이야기를\n발견하세요.';
@@ -59,9 +60,30 @@ const AssistantSuggestion = ({ prompt }: AssistantSuggestionProps) => {
       initialInput: prompt,
     });
 
+  const [recommendedSentences, setRecommendedSentences] = useState<
+    { sentence: string; story_id: number }[]
+  >([]);
+
   useEffect(() => {
     completeExpressiveness(prompt);
     completeReadability(prompt);
+
+    const getSentenceRecommendation = async () => {
+      try {
+        const response = await fetch('/api/sentence/recommendation', {
+          method: 'POST',
+          body: JSON.stringify({
+            sentence: prompt,
+          }),
+        });
+        const result = await response.json();
+        setRecommendedSentences(result.data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    getSentenceRecommendation();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prompt]);
 
@@ -76,6 +98,23 @@ const AssistantSuggestion = ({ prompt }: AssistantSuggestionProps) => {
         {
           title: '표현력을 높인 문장 제안',
           desc: expressivenessCompletion,
+        },
+        {
+          title: '다른 스토리에서 영감 얻기',
+          desc: (
+            <ul>
+              {recommendedSentences.map((item) => (
+                <Link
+                  key={item.sentence}
+                  href={`/story/${item.story_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <li>{item.sentence}</li>
+                </Link>
+              ))}
+            </ul>
+          ),
         },
       ]}
     />

--- a/src/app/_components/atoms/Assistant/AssistantContent/AssistantContent.tsx
+++ b/src/app/_components/atoms/Assistant/AssistantContent/AssistantContent.tsx
@@ -4,7 +4,7 @@ export interface AssistantContentProps {
   /** 어시스턴트 요소 내 제안할 제목 */
   title: string;
   /** 어시스턴트 요소 내 제안할 내용 */
-  desc: string;
+  desc: string | JSX.Element;
   /** 컴포넌트로 생성할 요소의 클래스명 */
   className?: string;
 }


### PR DESCRIPTION
## Description

- 저장된 문장들 중 카테고리가 같은 문장을 랜덤으로 최대 3개 추천하는 POST `/sentence/recommendation`을 추가했습니다.
- 문장 추천 API를 `/write`에 반영하였습니다. 추천된 문장을 클릭하면 해당 문장의 출처 스토리 페이지가 열립니다.
- 스토리 저장 시, 문장에 태그를 달 때 형식 측면에서의 카테고리는 제외하도록 변경하였습니다. (실제로 추천을 받아보니 유저 입장에서 크게 의미없는 문장을 추천받는 느낌이 들고, 태그를 2종류씩 달려고 하니 AI의 output token도 과도하게 늘어나는 문제가 있었습니다.)

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
